### PR TITLE
fix(Dockerfile): libffi was not pulled in as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.3
+FROM alpine:3.11.5
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
     apk update && apk add --no-cache libffi shellcheck bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10.3
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
-    apk update && apk add --no-cache shellcheck bash
+    apk update && apk add --no-cache libffi shellcheck bash
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
*  Update docker image version and add libffi.

The 3.10.4 image did not want to install shellcheck because of a missing 'libffi.so.7'

Adding libffi to the install did not help.
Bumping the Alpine docker version did not help.

Bumping the Alpine docker version AND add libffi to install command does help.

Signed-off-by: Mark Gomersbach <markgomersbach@gmail.com>