### PR TITLE
Locked shellcheck version to v0.7.0

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Update Shellcheck
+        run: ./src/download_shellcheck.sh
       - name: Run tests
         run: ./tests/test_runner
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.10.3
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
-    apk update && apk add --no-cache shellcheck bash
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.11/community" >> /etc/apk/repositories; \
+    apk update && apk add --no-cache bash shellcheck=0.7.0-r1
+
+RUN bash --version && shellcheck --version
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
 ```
 
 Run static analysis for a single shell script.
 ```yml
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
         with:
           path: "setup.sh"
 ```
@@ -37,7 +37,7 @@ Run static analysis for a single shell script.
 Run static analysis for multiple shell scripts **with or without** extension.
 ```yml
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
         with:
           path: "setup,deploy.sh"
 ```
@@ -45,7 +45,7 @@ Run static analysis for multiple shell scripts **with or without** extension.
 Run static analysis for all the shell scripts in a folder.
 ```yml
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
         with:
           path: "src"
 ```
@@ -53,7 +53,7 @@ Run static analysis for all the shell scripts in a folder.
 Run static analysis using a **wildcard** path
 ```yml
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
         with:
           path: "src/*.sh"
 ```

--- a/src/download_shellcheck.sh
+++ b/src/download_shellcheck.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Update shellcheck to the locked v0.7.0 version through the binary distribution
+scversion='v0.7.0'
+          
+wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
+shellcheck --version


### PR DESCRIPTION
Made the following changes to lock down the version of shellcheck (v0.7.0):
- Dockerfile - users will be restricted to use the v0.7.0 version
- src/download_shellcheck.sh - action workflow to test the shellcheck action is also set to version v0.7.0

Any new versions of alpine, shellcheck or future dependencies will need to be tested prior to release