### PR TITLE
Add support for 'latest' tag

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,9 +10,11 @@ jobs:
     steps:
     - name: Checkout 
       uses: actions/checkout@v1
+
     - name: Get version
       id: app-version
       run: echo ::set-output name=VERSION::$(./docs/version)
+
     - name: Tag commit and release
       uses: ncipollo/release-action@v1
       with:
@@ -21,3 +23,7 @@ jobs:
         commit: master
         name: Shell Linter v0.3.0
         bodyFile: ./docs/release_notes/v0.3.0.md
+
+    - name: Update latest tag
+      run: ./src/tagging.sh ${{ secrets.GITHUB_TOKEN }}
+    

--- a/src/tagging.sh
+++ b/src/tagging.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+token=$1
+repo_owner="azohra"
+repo_name="shell-linter"
+tag_name="latest"
+commit_sha=$(git log -n1 --format=format:"%H")
+
+create_tag(){
+command="curl -i \
+--request POST \
+-u username:$token \
+--data '{\"ref\": \"refs/tags/$tag_name\",\"sha\": \"$commit_sha\"}' \
+https://api.github.com/repos/${repo_owner}/${repo_name}/git/refs"
+
+git tag $tag_name
+eval "$command"
+}
+
+update_tag() {
+command="curl -i \
+--request PATCH \
+-u username:$token \
+--data '{\"sha\": \"$commit_sha\", \"force\":true}' \
+https://api.github.com/repos/${repo_owner}/${repo_name}/git/refs/tags/$tag_name"
+
+eval "$command"
+}
+
+if git tag --list | grep -Eq "$tag_name" ; then
+    echo "Updating the 'latest' tag"
+    update_tag
+else
+    echo "Creating the 'latest' tag"
+    create_tag
+fi


### PR DESCRIPTION
This Pull Request adds a 'latest' tag that points to the latest stable version of the shell-linter action.