### PR TITLE
Allow run on ARM64 runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.13.6
 
+ARG TARGETARCH
+
 RUN apk update && apk add --no-cache bash
-RUN bash --version 
+RUN bash --version
 
 COPY ./src/install_shellcheck.sh ./install_shellcheck.sh
-RUN ./install_shellcheck.sh
+RUN ./install_shellcheck.sh $TARGETARCH
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/src/install_shellcheck.sh
+++ b/src/install_shellcheck.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-scversion='v0.7.2'
-          
-wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+arch=`([[ $1 = "arm64" ]] && echo "aarch64" || echo $1)`
+scversion='v0.10.0'
+
+wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.${arch?}.tar.xz" | tar -xJv
 cp "shellcheck-${scversion}/shellcheck" /usr/local/bin
 rm -rf "shellcheck-${scversion}"
 shellcheck --version


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have created an issue prior to creating this pull request
- [x] I have provided a detailed description and motivation regarding the change below
- [x] I have updated the test suite and documentation to support my change

### Corresponding Issue
<!-- Please add the reference to the issue this change is required for. -->

#54 


### Description of Change
<!-- Please provide information regarding the change. -->

1. Upgrade shellcheck to v10
2. Allow download the right binary based on TARGETARCH 


### Motivation and Context
<!-- Please provide why this change was required. -->

GitHub allow ARM64 runner which save 37% of cost
